### PR TITLE
Add QA process, and additional user prefs

### DIFF
--- a/public/assets/js/build.js
+++ b/public/assets/js/build.js
@@ -46,10 +46,10 @@ $(document).ready(function() {
                     setTimeout(function() {
                         var $resultsUL = $('main').append('<section id="ABResults"><h1>Results</h1></section>').find('#ABResults').append('<ul>').find('ul');
                         $resultsUL.append('<li><a href="http://example.com?distribution-link">Live Distribution</a></li>');
-                    }, 15000);
+                    }, 7500);
 
                 }, false);
-            }, 15000);
+            }, 7500);
         });
 
         function fakeStatus($statusUL, messages) {
@@ -65,11 +65,11 @@ $(document).ready(function() {
                     if (dots === 3) {
                         clearInterval(addDots);
                     }
-                }, 1000);
+                }, 500);
 
                 setTimeout(function() {
                     $statusUL.find('li:last-child').append(' done');
-                }, 4000);
+                }, 2000);
             }
 
             addMessage();
@@ -79,7 +79,7 @@ $(document).ready(function() {
                 if (messages.length === 0) {
                     clearInterval(addMessages);
                 }
-            }, 5000);
+            }, 2500);
         }
     }());
 

--- a/views/index.html
+++ b/views/index.html
@@ -19,6 +19,21 @@
                 <label>Email address: <input type="text" /></label>
             </div>
         </fieldset>
+        <fieldset id="funnelcake">
+            <legend>Funnelcake</legend>
+            <div class="field page">
+                <label>Version #: </label><input type="text" />
+            </div>
+            <div class="field page">
+                <label>Build Channel: </label><input type="text" />
+            </div>
+            <div class="field page">
+                <label>Language: </label><input type="text" />
+            </div>
+            <div class="field page">
+                <label>OS: </label><input type="text" />
+            </div>
+        </fieldset>
         <fieldset id="modifications">
             <legend>Modifications</legend>
             <div class="field page">
@@ -33,11 +48,17 @@
                 <label><input type="checkbox" />Homepage</label>
                 <input placeholder="http://example.com" type="text" class="url hidden" />
             </div>
+            <div class="field page">
+                <label><input type="checkbox" checked/>Advanced Newtab (suggested tiles, etc)</label>
+            </div>
         </fieldset>
-        <div class="field">
-            <label for="other-notes">Other notes:</label>
-            <textarea id="other-notes" rows="10" cols="100"></textarea>
-        </div>
+        <fieldset id="distribution">
+            <legend>Distribution</legend>
+            <div class="field page">
+                <label>Sample Size: </label><input type="text" />
+            </div>
+        </fieldset>
+
         <input type="submit" value="Build funnelcake" />
     </form>
 {% endblock %}


### PR DESCRIPTION
@openjck Some notes about this PR:
- Added additional funnelcake meta information for repack.cfg
- Added Optimizely distribution section: Sample Size
- Removed the "additional notes" field. We aren't sure whether or not we can automate the documentation piece in mana, so this field wouldn't do much in an early version. Unless we created some sort of outline that the user could copy/paste into mana. Let me know what you think about this.
- Sped up build "status" process for example/testing sake :)
